### PR TITLE
Add various fields to TrackStatus and ScoreStatus objects

### DIFF
--- a/Protocol.md
+++ b/Protocol.md
@@ -146,12 +146,12 @@ Type | Status | Description
   "startTime": Number, // Seconds
   "endTime"  : Number, // Seconds
 
-  "difficulty": String, 
-  "rating"    : Number,
+  "difficulty": String, // Difficulty name (e.g. "Expert")
+  "rating"    : Number, // Difficulty number
   "maxScore"  : Number, // Maximum possible score
-        
+
   "isCustom": Boolean,
-  "filename": String, // srtb filename (if custom)
+  "filename": String,  // SRTB filename (if custom)
 }
 ```
 

--- a/Protocol.md
+++ b/Protocol.md
@@ -101,13 +101,15 @@ Type | Status | Description
 
 ```js
 {
-  "score"     : Number, // Current score
-  "combo"     : Number, // Current combo
-  "maxCombo"  : Number, // Largest achieved combo
-  "fullCombo" : String,
-  "health"    : Number, // Current health
-  "maxHealth" : Number, // Total health
-  "multiplier": Number, // Score multiplier
+  "score"        : Number, // Current score
+  "combo"        : Number, // Current combo
+  "maxCombo"     : Number, // Largest achieved combo
+  "fullCombo"    : String,
+  "health"       : Number, // Current health
+  "maxHealth"    : Number, // Total health
+  "multiplier"   : Number, // Score multiplier
+  "baseScore"    : Number, // Score (without multipliers)
+  "baseScoreLost": Number // Score (without multipliers) lost to mistakes
 }
 ```
 
@@ -144,8 +146,12 @@ Type | Status | Description
   "startTime": Number, // Seconds
   "endTime"  : Number, // Seconds
 
-  "difficulty": String,
-  "isCustom"  : Boolean,
+  "difficulty": String, 
+  "rating"    : Number,
+  "maxScore"  : Number, // Maximum possible score
+        
+  "isCustom": Boolean,
+  "filename": String, // srtb filename (if custom)
 }
 ```
 

--- a/SpinStatus/Directory.Build.targets
+++ b/SpinStatus/Directory.Build.targets
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project>
+    <Target Name="PostBuildScript" AfterTargets="AfterBuild">
+        <Message Text="-> Copying $(TargetPath) to $(BaseGameDir)\BepInEx\plugins" Importance="high"/>
+        <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(BaseGameDir)\BepInEx\plugins"
+              SkipUnchangedFiles="false" OverwriteReadOnlyFiles="true"/>
+    </Target>
+    <Target Name="PostBuildScriptDebug" AfterTargets="AfterBuild" Condition="'$(Configuration)' == 'Debug'">
+        <Message Text="-> Copying $(ProjectDir)bin\Debug\$(TargetFramework)\$(AssemblyName).pdb to $(BaseGameDir)\BepInEx\plugins" Importance="high"/>
+        <Copy SourceFiles="$(ProjectDir)bin\Debug\$(TargetFramework)\$(AssemblyName).pdb" DestinationFolder="$(BaseGameDir)\BepInEx\plugins"
+              SkipUnchangedFiles="false" OverwriteReadOnlyFiles="true"/>
+    </Target>
+</Project>

--- a/SpinStatus/Patches.cs
+++ b/SpinStatus/Patches.cs
@@ -3,7 +3,6 @@ using SimpleJSON;
 using UnityEngine;
 using System.Linq;
 using System;
-using System.Collections.Generic;
 using System.IO;
 
 namespace SpinStatus.Patches

--- a/SpinStatus/Patches.cs
+++ b/SpinStatus/Patches.cs
@@ -73,6 +73,8 @@ namespace SpinStatus.Patches
                     scoreJSON["health"] = playState.health;
                     scoreJSON["maxHealth"] = playState.MaxHealth;
                     scoreJSON["multiplier"] = playState.multiplier;
+                    scoreJSON["baseScore"] = scoreState.CurrentTotals.baseScore;
+                    scoreJSON["baseScoreLost"] = scoreState.CurrentTotals.baseScoreLost;
 
                     Server.ServerBehavior.SendMessage(scoreEventJSON);
                 }

--- a/SpinStatus/Patches.cs
+++ b/SpinStatus/Patches.cs
@@ -73,7 +73,6 @@ namespace SpinStatus.Patches
                     scoreJSON["health"] = playState.health;
                     scoreJSON["maxHealth"] = playState.MaxHealth;
                     scoreJSON["multiplier"] = playState.multiplier;
-                    scoreJSON["maxScore"] = playState.maxPossibleScoreState.MaxPossibleScore;
 
                     Server.ServerBehavior.SendMessage(scoreEventJSON);
                 }

--- a/SpinStatus/Patches.cs
+++ b/SpinStatus/Patches.cs
@@ -117,6 +117,8 @@ namespace SpinStatus.Patches
 
             TrackDataSegment trackDataSegment = trackData.GetFirstSegment();
             TrackInfoMetadata trackMeta = trackDataSegment.GetTrackInfoMetadata();
+            TrackInfoAssetReference assetInfo = trackDataSegment.metadata.TrackInfoRef;
+            TrackDataMetadata mapData = trackDataSegment.GetTrackDataMetadata();
 
             playState.trackData.GetFirstSegment();
 
@@ -129,9 +131,12 @@ namespace SpinStatus.Patches
             trackJSON["feat"] = trackMeta.featArtists;
             trackJSON["charter"] = trackMeta.charter;
             trackJSON["difficulty"] = playState.CurrentDifficulty.ToString();
+            trackJSON["rating"] = mapData.DifficultyRating;
             trackJSON["isCustom"] = trackMeta.isCustom;
             trackJSON["startTime"] = playState.startTrackTime;
             trackJSON["endTime"] = trackData.GameplayEndTick.ToSecondsFloat();
+            trackJSON["filename"] = trackMeta.isCustom ? assetInfo.customFile.FileNameNoExtension : "";
+            trackJSON["maxScore"] = mapData.MaxScore;
 
             var colorJSON = trackJSON["palette"].AsObject;
 

--- a/SpinStatus/Patches.cs
+++ b/SpinStatus/Patches.cs
@@ -73,6 +73,7 @@ namespace SpinStatus.Patches
                     scoreJSON["health"] = playState.health;
                     scoreJSON["maxHealth"] = playState.MaxHealth;
                     scoreJSON["multiplier"] = playState.multiplier;
+                    scoreJSON["maxScore"] = playState.maxPossibleScoreState.MaxPossibleScore;
 
                     Server.ServerBehavior.SendMessage(scoreEventJSON);
                 }

--- a/SpinStatus/SpinStatus.csproj
+++ b/SpinStatus/SpinStatus.csproj
@@ -30,13 +30,16 @@
 
 <ItemGroup>
     <Reference Include="Assembly-CSharp" Publicize="true">
-        <HintPath>$(BaseGameDir)\SpinRhythm_Data\Managed\Assembly-CSharp.dll</HintPath>
+        <HintPath Condition="Exists('..\..\SpinRhythm_Data')">..\..\SpinRhythm_Data\Managed\Assembly-CSharp.dll</HintPath>
+        <HintPath Condition="Exists('$(BaseGameDir)\SpinRhythm_Data')">$(BaseGameDir)\SpinRhythm_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="SSD.Game">
-        <HintPath>$(BaseGameDir)\SpinRhythm_Data\Managed\SSD.Game.dll</HintPath>
+        <HintPath Condition="Exists('..\..\SpinRhythm_Data')">..\..\SpinRhythm_Data\Managed\SSD.Game.dll</HintPath>
+        <HintPath Condition="Exists('$(BaseGameDir)\SpinRhythm_Data')">$(BaseGameDir)\SpinRhythm_Data\Managed\SSD.Game.dll</HintPath>
     </Reference>
     <Reference Include="Spin.Game.TrackPlaybackSystem">
-        <HintPath>$(BaseGameDir)\SpinRhythm_Data\Managed\Spin.Game.TrackPlaybackSystem.dll</HintPath>
+        <HintPath Condition="Exists('..\..\SpinRhythm_Data')">..\..\SpinRhythm_Data\Managed\Spin.Game.TrackPlaybackSystem.dll</HintPath>
+        <HintPath Condition="Exists('$(BaseGameDir)\SpinRhythm_Data')">$(BaseGameDir)\SpinRhythm_Data\Managed\Spin.Game.TrackPlaybackSystem.dll</HintPath>
     </Reference>
 </ItemGroup>
 
@@ -50,5 +53,5 @@
 <ItemGroup Condition = "'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">
     <PackageReference Include = "Microsoft.NETFramework.ReferenceAssemblies" Version = "1.0.2" PrivateAssets = "all" />
 </ItemGroup>
-    
+
 </Project>

--- a/SpinStatus/SpinStatus.csproj
+++ b/SpinStatus/SpinStatus.csproj
@@ -6,18 +6,19 @@
 </PropertyGroup>
 
 <PropertyGroup>
-<TargetFramework>netstandard2.1</TargetFramework>
-<AssemblyName>SpinStatus</AssemblyName>
-<Product>SpinStatus</Product>
-<Version>0.4.0</Version>
-<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-<LangVersion>latest</LangVersion>
-<RestoreAdditionalProjectSources>
-    https://api.nuget.org/v3/index.json;
-    https://nuget.bepinex.dev/v3/index.json;
-    https://nuget.samboy.dev/v3/index.json
-</RestoreAdditionalProjectSources>
-<RootNamespace>xyz.bacur</RootNamespace>
+    <TargetFramework>net472</TargetFramework>
+    <AssemblyName>SpinStatus</AssemblyName>
+    <Product>SpinStatus</Product>
+    <Version>0.4.0</Version>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>latest</LangVersion>
+    <RestoreAdditionalProjectSources>
+        https://api.nuget.org/v3/index.json;
+        https://nuget.bepinex.dev/v3/index.json;
+        https://nuget.samboy.dev/v3/index.json
+    </RestoreAdditionalProjectSources>
+    <RootNamespace>xyz.bacur</RootNamespace>
+    <BaseGameDir>D:\Steam\steamapps\common\Spin Rhythm</BaseGameDir>
 </PropertyGroup>
 
 <ItemGroup>
@@ -29,13 +30,13 @@
 
 <ItemGroup>
     <Reference Include="Assembly-CSharp" Publicize="true">
-        <HintPath>..\..\SpinRhythm_Data\Managed\Assembly-CSharp.dll</HintPath>
+        <HintPath>$(BaseGameDir)\SpinRhythm_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="SSD.Game">
-        <HintPath>..\..\SpinRhythm_Data\Managed\SSD.Game.dll</HintPath>
+        <HintPath>$(BaseGameDir)\SpinRhythm_Data\Managed\SSD.Game.dll</HintPath>
     </Reference>
     <Reference Include="Spin.Game.TrackPlaybackSystem">
-        <HintPath>..\..\SpinRhythm_Data\Managed\Spin.Game.TrackPlaybackSystem.dll</HintPath>
+        <HintPath>$(BaseGameDir)\SpinRhythm_Data\Managed\Spin.Game.TrackPlaybackSystem.dll</HintPath>
     </Reference>
 </ItemGroup>
 
@@ -49,4 +50,5 @@
 <ItemGroup Condition = "'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">
     <PackageReference Include = "Microsoft.NETFramework.ReferenceAssemblies" Version = "1.0.2" PrivateAssets = "all" />
 </ItemGroup>
+    
 </Project>


### PR DESCRIPTION
Was working on my own overlays and wanted to add a few things

### TrackStatus
- `rating` is the set difficulty rating for the difficulty being played
- `filename` is the srtb filename if the map being played is custom, otherwise it's blank (can be used for direct SpinShare calls)
- `maxScore` is the maximum possible score for the difficulty being played

### ScoreStatus
- `baseScore` is the current score without multipliers applied
- `baseScoreLost` is the amount of score (without multipliers) lost from mistakes
  - Both of these can be used to calculate accuracy (can't currently do this)

(the project changes can be ignored, was only getting rider to shush)
(that revert commit was me assuming things by the variable names, can be ignored)